### PR TITLE
fix(prod-config): use absolute paths in webpack's output

### DIFF
--- a/config/_production.js
+++ b/config/_production.js
@@ -7,5 +7,6 @@ export default () => ({
     chunks : true,
     chunkModules : true,
     colors : true
-  }
+  },
+  compiler_public_path: '/'
 })


### PR DESCRIPTION
Building the project with the production configuration outputs an html file with the js and css linked as relative urls and if you have subpaths in your app, then anyone arriving at a subpath first will fail to find the resources as it will look for them in that subpath on the server.
